### PR TITLE
using Docker Toolbox on Win10 Home the dockerfile interrupted requiri…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 
 # docker run -d -p 8787:8787 -e PASSWORD=??? --name sposm sposm_ide
 
-# Do not forget to set a passord, as depending on your configuration
+# Do not forget to set a password, as depending on your configuration
 # the container might be accessible in the network!
 
 # Access your new integrated development environment in your browser
@@ -63,6 +63,8 @@ RUN apt-get update \
 # Install some additional tex packages
 
 RUN tlmgr option repository http://mirror.ctan.org/systems/texlive/tlnet
+
+RUN tlmgr update --self
 
 RUN tlmgr install multirow xcolor colortbl wrapfig float tabu varwidth \
   threeparttable threeparttablex environ trimspaces ulem makecell endfloat \


### PR DESCRIPTION
…ng RUN tlmgr update --self

The dockerfile itself suggested this change.
I wanted to offer it here but I also see the problems that in the future this might lead to other inompatibilities if "tlmgr" would become updated always to the newest version.

Please let me know what you think about this issue.